### PR TITLE
Update guzzle psr7 to ^2.0 so it can be installed alongside Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=5.4.2",
-        "guzzlehttp/psr7": "^1.0"
+        "guzzlehttp/psr7": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.*",


### PR DESCRIPTION
…el 8

Laravel 8 and its packages require guzzle and guzzlehttp/psr7@^2.0.0.

I can't seem to use this package https://github.com/butschster/kraken-api-client/ on Laravel because it conflicts with https://github.com/ratchetphp/RFC6455's requirement on guzzlehttp/psr7@^1.0.0